### PR TITLE
Aanpassingen om een removeStock operatie te laten uitvoeren bij afslu…

### DIFF
--- a/eindwerkJava2/src/main/java/com/example/eindwerkJava2/model/SaleHeader.java
+++ b/eindwerkJava2/src/main/java/com/example/eindwerkJava2/model/SaleHeader.java
@@ -32,4 +32,7 @@ public class SaleHeader {
         this.totalPrice = 0;
     }
 
+    public String getNameSalesPerson() {
+        return nameSalesPerson;
+    }
 }

--- a/eindwerkJava2/src/main/java/com/example/eindwerkJava2/model/Warehouse.java
+++ b/eindwerkJava2/src/main/java/com/example/eindwerkJava2/model/Warehouse.java
@@ -38,6 +38,9 @@ public class Warehouse {
         this.setWarehouseName(warehouseName);
     }
 
+    @Column(name = "store")
+    private boolean store;
+
 
     /**
      * Gets active warehouse.
@@ -65,12 +68,14 @@ public class Warehouse {
      * @param warehouseName   the warehouse name
      * @param locations       link to the location table
      * @param activeWarehouse the active parameter for the warehouse
+     * @param store           checked if the warehouse is the store
      */
-    public Warehouse(Long warehouseId, String warehouseName, List<Location> locations, int activeWarehouse) {
+    public Warehouse(Long warehouseId, String warehouseName, List<Location> locations, int activeWarehouse, boolean store) {
         this.warehouseId = warehouseId;
         this.warehouseName = warehouseName;
         this.locations = locations;
         this.activeWarehouse = activeWarehouse;
+        this.store = store;
     }
 
 }

--- a/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/MutationService.java
+++ b/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/MutationService.java
@@ -1,9 +1,11 @@
 
 package com.example.eindwerkJava2.service;
 
+import com.example.eindwerkJava2.model.Article;
 import com.example.eindwerkJava2.model.Mutation;
 import com.example.eindwerkJava2.wrappers.SuccessEvaluator;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MutationService {
@@ -18,4 +20,5 @@ public interface MutationService {
      Optional<Mutation> findById(Long id);
      void deleteMutation(Mutation mutation);
      Double getArticleAmount(Mutation mutation);
+     List<Mutation> findByArticle(Article article);
 }

--- a/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/MutationServiceImpl.java
+++ b/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/MutationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.eindwerkJava2.service;
 
+import com.example.eindwerkJava2.model.Article;
 import com.example.eindwerkJava2.model.Mutation;
 import com.example.eindwerkJava2.model.Stock;
 import com.example.eindwerkJava2.repositories.MutationRepository;
@@ -188,6 +189,11 @@ public class MutationServiceImpl implements MutationService {
         }
 
         return totalamount;
+    }
+
+    @Override
+    public List<Mutation> findByArticle(Article article){
+        return mutationRepository.findByArticle(article);
     }
 
 }

--- a/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/TransactionService.java
+++ b/eindwerkJava2/src/main/java/com/example/eindwerkJava2/service/TransactionService.java
@@ -22,6 +22,10 @@ public class TransactionService {
         return this.transactionRepository.findAll();
     }
 
+    public TransactionType getSaleType(){
+        return transactionRepository.findByTransactionTypeName("Opboeken").get();
+    }
+
 
 
 }


### PR DESCRIPTION
…iten verkoop:

- SaleLineService: aanmaken en invullen van een mutation object en dit naar de removeStock method van de mutationservice sturen

- Warehouse model: toevoeging van een 'store' kolom om aan te duiden welk warehouse een winkel is. Dit is nodig om de correcte locatie van het artikel op te halen die wordt ingevuld in de mutatie van SaleLineService

- TransactionService: method getSaleType toegevoegd om Transactiontype 'Opboeken' op te halen voor de mutatie van de SaleLineService

- SaleHeader: een getNameSalesPerson toegevoegd om de naam van de verkoper uit de tabel van Users op te halen voor de mutatie van de SaleLineService

-MutationServiceImpl & mutationservice: method findByArticle toegevoegd die alle mutaties van een verkocht artikel teruggeeft waardoor de huidige locatie van dit artikel in de winkel kan worden gevonden.